### PR TITLE
Added in the filtering of PurpleAir PM2.5 with dust events

### DIFF
--- a/airfuse/drivers.py
+++ b/airfuse/drivers.py
@@ -14,7 +14,7 @@ import warnings
 
 
 def fuse(
-    obssource, species, startdate, model, bbox=None, cv_only=False,
+    obssource, species, startdate, model, bbox=None, dust_ev_filt=False, cv_only=False,
     outdir=None, overwrite=False, api_key=None, verbose=0, njobs=None,
     modvar=None, obsdf=None, format='csv', **kwds
 ):
@@ -36,6 +36,8 @@ def fuse(
         wlon, slat, elon, nlat in decimal degrees east and north
         lon >= -180 and lon <= 180
         lat >= -90 and lat <= 90
+    dust_ev_filt: bool
+        If True, this removes sites where a dust event is likely
     cv_only : bool
         Only perform the cross-validation
     outdir : str or None
@@ -119,8 +121,9 @@ def fuse(
             obsdf = pair_aqs(date, bbox, proj, modvar, obskey)
         elif obssource == 'purpleair':
             obsdf = pair_purpleair(
-                date, bbox, proj, modvar, obskey, api_key=api_key
+            date, bbox, proj, modvar, obskey, api_key=api_key, dust_ev_filt=dust_ev_filt
             )
+
     logging.info(f'{obssource} N={obsdf.shape[0]}')
     vardescs = {
       'NAQFC': 'NOAA Forecast (NAQFC)',

--- a/airfuse/drivers.py
+++ b/airfuse/drivers.py
@@ -14,9 +14,9 @@ import warnings
 
 
 def fuse(
-    obssource, species, startdate, model, bbox=None, dust_ev_filt=False, cv_only=False,
-    outdir=None, overwrite=False, api_key=None, verbose=0, njobs=None,
-    modvar=None, obsdf=None, format='csv', **kwds
+    obssource, species, startdate, model, bbox=None, dust_ev_filt=False,
+    cv_only=False, outdir=None, overwrite=False, api_key=None, verbose=0,
+    njobs=None, modvar=None, obsdf=None, format='csv', **kwds
 ):
     """
     Must accept all arguments from airfuse.parser.parse_args
@@ -120,9 +120,9 @@ def fuse(
         elif obssource == 'aqs':
             obsdf = pair_aqs(date, bbox, proj, modvar, obskey)
         elif obssource == 'purpleair':
-            obsdf = pair_purpleair(
-            date, bbox, proj, modvar, obskey, api_key=api_key, dust_ev_filt=dust_ev_filt
-            )
+            obsdf = pair_purpleair(date, bbox, proj, modvar,
+                                   obskey, api_key=api_key,
+                                   dust_ev_filt=dust_ev_filt)
 
     logging.info(f'{obssource} N={obsdf.shape[0]}')
     vardescs = {

--- a/airfuse/obs/purpleair.py
+++ b/airfuse/obs/purpleair.py
@@ -2,7 +2,8 @@ __all__ = ['pair_purpleair']
 
 
 def pair_purpleair(
-    bdate, bbox, proj, var, spc, api_key=None, exclude_stations=None, dust_ev_filt=False
+    bdate, bbox, proj, var, spc, api_key=None, exclude_stations=None,
+    dust_ev_filt=False
 ):
     """
     Arguments
@@ -76,38 +77,50 @@ def pair_purpleair(
             unit_keys=False, parse_dates=True
         )
 
-        # Merge PM 0.3um and PM5um counts and delete rows with incomplete data between the two fields
-        pm03df.loc[:,'new_index'] = pm03df['STATION'].astype(str)+'_'+pm03df['Timestamp'].astype(str)
-        pm5df.loc[:,'new_index'] = pm5df['STATION'].astype(str)+'_'+pm5df['Timestamp'].astype(str)
-
+        # Merge PM 0.3um and PM5um counts and delete rows
+        # with incomplete data between the two fields
+        pm03df['new_index'] = (
+            pm03df['STATION'].astype(str) + '_'
+            + pm03df['Timestamp'].astype(str)
+        )
+        pm5df['new_index'] = (
+            pm5df['STATION'].astype(str) + '_' + pm5df['Timestamp'].astype(str)
+        )
         pm03df.set_index('new_index', inplace=True)
         pm5df.set_index('new_index', inplace=True)
 
         pm03df = pm03df[['0_3_um_count_hourly']]
         pm5df = pm5df[['5_um_count_hourly']]
-        padf_dust = pd.merge(pm03df, pm5df, how='inner',on='new_index')
+        padf_dust = pd.merge(pm03df, pm5df, how='inner', on='new_index')
 
         # Calculate PM 0.3um counts/PM 5um counts (dust criteria) ratio
-        padf_dust = padf_dust.astype({'0_3_um_count_hourly':float,'5_um_count_hourly':float})
-        padf_dust.loc[:,'0.3um ct/5um ct'] = padf_dust['0_3_um_count_hourly']/padf_dust['5_um_count_hourly']
+        padf_dust = padf_dust.astype({'0_3_um_count_hourly': float,
+                                      '5_um_count_hourly': float})
+        padf_dust['0.3um ct/5um ct'] = (
+            padf_dust['0_3_um_count_hourly'] / padf_dust['5_um_count_hourly']
+        )
         padf_dust.replace([np.inf, -np.inf], np.nan, inplace=True)
-        
-        # Aggregate up to the hour for dust criteria ratio
-        padf_dust.loc[:,'STATION-TIME'] = padf_dust.index
-        padf_dust['STATION-TIME'] = padf_dust['STATION-TIME'].str[:-11]
-        padf_dust = padf_dust[['STATION-TIME','0.3um ct/5um ct']]
 
-        padf_dust = padf_dust.groupby('STATION-TIME',as_index=False).mean()
-        padf_dust[['STATION','Timestamp(UTC) Hourly']] = padf_dust['STATION-TIME'].str.split('_',expand=True)
+        # Aggregate up to the hour for dust criteria ratio
+        padf_dust.loc[:, 'STATION-TIME'] = padf_dust.index
+        padf_dust['STATION-TIME'] = padf_dust['STATION-TIME'].str[:-11]
+        padf_dust = padf_dust[['STATION-TIME', '0.3um ct/5um ct']]
+
+        padf_dust = padf_dust.groupby('STATION-TIME',
+                                      as_index=False).mean()
+        padf_dust[['STATION', 'Timestamp(UTC) Hourly']] = (
+            padf_dust['STATION-TIME'].str.split('_', expand=True)
+        )
         padf_dust['STATION'] = padf_dust['STATION'].astype(np.int64)
 
-        # Filter hourly pm25 for non-dust event measurements 
+        # Filter hourly pm25 for non-dust event measurements
         padf_dust = padf_dust[padf_dust['0.3um ct/5um ct'] > 190]
 
         padf_aft = pd.merge(padf, padf_dust, how='inner', on='STATION')
         removed_sta = len(padf) - len(padf_aft)
-        print('%s monitors removed due to dust event' %removed_sta)
-        padf_aft.drop(['Timestamp(UTC) Hourly','0.3um ct/5um ct'],axis=1,inplace=True)
+        print('%s monitors removed due to dust event' % removed_sta)
+        padf_aft.drop(['Timestamp(UTC) Hourly', '0.3um ct/5um ct'],
+                      axis=1, inplace=True)
         padf = padf_aft
 
     # Identify PurpleAir records to exclude

--- a/airfuse/obs/purpleair.py
+++ b/airfuse/obs/purpleair.py
@@ -2,7 +2,7 @@ __all__ = ['pair_purpleair']
 
 
 def pair_purpleair(
-    bdate, bbox, proj, var, spc, api_key=None, exclude_stations=None
+    bdate, bbox, proj, var, spc, api_key=None, exclude_stations=None, dust_ev_filt=False
 ):
     """
     Arguments
@@ -23,6 +23,8 @@ def pair_purpleair(
         If None, the API key must exist in ~/.purpleairkey
     exclude_stations : None or list
         List of stations to exclude.
+    dust_ev_filt : bool
+        If True, this removes sites where a dust event is likely
 
     Returns
     -------
@@ -56,10 +58,57 @@ def pair_purpleair(
         bbox=bbox, workdir=outdir
     )
     rsigapi.purpleair_kw['api_key'] = api_key
+
     padf = rsigapi.to_dataframe(
         'purpleair.pm25_corrected', bdate=bdate, edate=edate,
         unit_keys=False, parse_dates=True
     ).rename(columns=dict(pm25_corrected_hourly=spc))
+
+    if dust_ev_filt is True:
+        # Bring in PM 0.3um and PM 5um count data for dust event filtering
+        pm03df = rsigapi.to_dataframe(
+            'purpleair.0_3_um_count', bdate=bdate, edate=edate,
+            unit_keys=False, parse_dates=True
+        )
+
+        pm5df = rsigapi.to_dataframe(
+            'purpleair.5_um_count', bdate=bdate, edate=edate,
+            unit_keys=False, parse_dates=True
+        )
+
+        # Merge PM 0.3um and PM5um counts and delete rows with incomplete data between the two fields
+        pm03df.loc[:,'new_index'] = pm03df['STATION'].astype(str)+'_'+pm03df['Timestamp'].astype(str)
+        pm5df.loc[:,'new_index'] = pm5df['STATION'].astype(str)+'_'+pm5df['Timestamp'].astype(str)
+
+        pm03df.set_index('new_index', inplace=True)
+        pm5df.set_index('new_index', inplace=True)
+
+        pm03df = pm03df[['0_3_um_count_hourly']]
+        pm5df = pm5df[['5_um_count_hourly']]
+        padf_dust = pd.merge(pm03df, pm5df, how='inner',on='new_index')
+
+        # Calculate PM 0.3um counts/PM 5um counts (dust criteria) ratio
+        padf_dust = padf_dust.astype({'0_3_um_count_hourly':float,'5_um_count_hourly':float})
+        padf_dust.loc[:,'0.3um ct/5um ct'] = padf_dust['0_3_um_count_hourly']/padf_dust['5_um_count_hourly']
+        padf_dust.replace([np.inf, -np.inf], np.nan, inplace=True)
+        
+        # Aggregate up to the hour for dust criteria ratio
+        padf_dust.loc[:,'STATION-TIME'] = padf_dust.index
+        padf_dust['STATION-TIME'] = padf_dust['STATION-TIME'].str[:-11]
+        padf_dust = padf_dust[['STATION-TIME','0.3um ct/5um ct']]
+
+        padf_dust = padf_dust.groupby('STATION-TIME',as_index=False).mean()
+        padf_dust[['STATION','Timestamp(UTC) Hourly']] = padf_dust['STATION-TIME'].str.split('_',expand=True)
+        padf_dust['STATION'] = padf_dust['STATION'].astype(np.int64)
+
+        # Filter hourly pm25 for non-dust event measurements 
+        padf_dust = padf_dust[padf_dust['0.3um ct/5um ct'] > 190]
+
+        padf_aft = pd.merge(padf, padf_dust, how='inner', on='STATION')
+        removed_sta = len(padf) - len(padf_aft)
+        print('%s monitors removed due to dust event' %removed_sta)
+        padf_aft.drop(['Timestamp(UTC) Hourly','0.3um ct/5um ct'],axis=1,inplace=True)
+        padf = padf_aft
 
     # Identify PurpleAir records to exclude
     # missing value or unreasonably high value

--- a/airfuse/pm.py
+++ b/airfuse/pm.py
@@ -180,10 +180,10 @@ nearest obs.
         )
 
     if padf is None:
-        padf = pair_purpleair(
-            date, bbox, proj, modvar, obskey, api_key=api_key, dust_ev_filt=dust_ev_filt,
-            exclude_stations=exclude_stations
-        )
+        padf = pair_purpleair(date, bbox, proj, modvar, obskey,
+                              api_key=api_key, dust_ev_filt=dust_ev_filt,
+                              exclude_stations=exclude_stations)
+
     logging.info(f'PurpleAir N={padf.shape[0]}')
     fdesc = '\n'.join([fdesc, f'PurpleAir N={padf.shape[0]}'])
     ann = andf.shape[0]

--- a/airfuse/pm.py
+++ b/airfuse/pm.py
@@ -17,7 +17,7 @@ import pandas as pd
 
 
 def pmfuse(
-    startdate, model, bbox=None, cv_only=False,
+    startdate, model, bbox=None, dust_ev_filt=False, cv_only=False,
     outdir=None, overwrite=False, api_key=None, verbose=0, njobs=None,
     modvar=None, andf=None, padf=None, exclude_stations=True, format='csv',
     **kwds
@@ -35,6 +35,8 @@ def pmfuse(
         wlon, slat, elon, nlat in decimal degrees east and north
         lon >= -180 and lon <= 180
         lat >= -90 and lat <= 90
+    dust_ev_filt: bool
+        If True, this removes sites where a dust event is likely
     cv_only : bool
         Only perform the cross-validation
     outdir : str or None
@@ -179,7 +181,7 @@ nearest obs.
 
     if padf is None:
         padf = pair_purpleair(
-            date, bbox, proj, modvar, obskey, api_key=api_key,
+            date, bbox, proj, modvar, obskey, api_key=api_key, dust_ev_filt=dust_ev_filt,
             exclude_stations=exclude_stations
         )
     logging.info(f'PurpleAir N={padf.shape[0]}')


### PR DESCRIPTION
It has recently been documented that PurpleAir monitors tend to underestimate PM2.5 whenever dust is a dominant source of PM ([Jaffe et al., 2023](https://amt.copernicus.org/articles/16/1311/2023/)). The proxy for dust used in this publication is when the ratio of PM 0.3um counts/PM 5um counts (also measured by PurpleAir) is less than 190.

I have added in dust event filtering in the 'fuse' and 'pmfuse' functions as a boolean option (default set to False). Prior to code changes I ran 'fuse' and 'pmfuse' for Utah and some surrounding states for 05-13-2025 with these plotted results:

<img width="989" height="691" alt="image" src="https://github.com/user-attachments/assets/469cf4ca-ece6-48c0-a7c7-25bee3b70862" />

After implementing code changes I reran these functions with 'dust_ev_filt' set to it's default False to ensure that inadvertent changes were not made:

<img width="995" height="694" alt="image" src="https://github.com/user-attachments/assets/afbb0705-a0b9-4536-9e1c-82b904af9c9a" />

I then ran with 'dust_ev_filt' set to True:

<img width="1013" height="698" alt="image" src="https://github.com/user-attachments/assets/a5783f2b-933b-42d1-a9b3-5eaf2cec898e" />

With doing this a total of 390 monitors were removed (printed out when 'dust_ev_filt' = True; we can get rid of this if you want, I think it's helpful to get an idea) given the PM count ratio fell below 190 indicating a dust even. The fused map of PM2.5 in the top left corner has a larger area to the southwest of Salt Lake with higher PM2.5 concentrations given this filtering.